### PR TITLE
Log warnings raised by Ghostscript

### DIFF
--- a/lib/grim.rb
+++ b/lib/grim.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require 'safe_shell'
+require 'logger'
 
 module Grim
   # Default resize output width, any positive integer
@@ -43,6 +44,18 @@ module Grim
   #
   def self.reap(path)
     Grim::Pdf.new(path)
+  end
+
+  def self.logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  def self.logger=(logger)
+    @logger = logger
+  end
+
+  def self.logging?
+    ENV['GRIM_LOGGING']
   end
 end
 

--- a/lib/grim/pdf.rb
+++ b/lib/grim/pdf.rb
@@ -31,6 +31,7 @@ module Grim
     def count
       @count ||= begin
         result = SafeShell.execute("gs", "-dNODISPLAY", "-q", "-sFile=#{@path}", File.expand_path('../../../lib/pdf_info.ps', __FILE__))
+        result.scan(WarningRegex) {|message| Grim.logger.warn message } if Grim.logging?
         result.gsub(WarningRegex, '').to_i
       end
     end


### PR DESCRIPTION
Added some logging to STDOUT after running into some issues trying to parse a PDF.

It's off by default as I'm not sure what the preferred behavior is, but if you set the GRIM_LOGGING environment variable, warnings will be logged to STDOUT in Grim::Pdf#count before the result is `gsub`ed and returned.

Might be worthwhile adding logging statements elsewhere (showing which page it's processing or something along those lines).
