### PR TITLE
Added option to specify the colorspace used with image magic

### DIFF
--- a/lib/grim.rb
+++ b/lib/grim.rb
@@ -14,6 +14,9 @@ module Grim
   # Default density, any positive integer
   DENSITY = 300
 
+  # Default colorspace
+  COLORSPACE = "RGB"
+
   # Default exception class for Grim.
   class Exception < ::StandardError
   end

--- a/lib/grim/image_magick_processor.rb
+++ b/lib/grim/image_magick_processor.rb
@@ -23,8 +23,9 @@ module Grim
       width   = options.fetch(:width,   Grim::WIDTH)
       density = options.fetch(:density, Grim::DENSITY)
       quality = options.fetch(:quality, Grim::QUALITY)
+      colorspace = options.fetch(:colorspace, Grim::COLORSPACE)
       command = [@imagemagick_path, "-resize", width.to_s, "-antialias", "-render",
-        "-quality", quality.to_s, "-colorspace", "RGB",
+        "-quality", quality.to_s, "-colorspace", colorspace,
         "-interlace", "none", "-density", density.to_s,
         "#{Shellwords.shellescape(pdf.path)}[#{index}]", path]
       command.unshift("PATH=#{File.dirname(@ghostscript_path)}:#{ENV['PATH']}") if @ghostscript_path

--- a/spec/lib/grim/image_magick_processor_spec.rb
+++ b/spec/lib/grim/image_magick_processor_spec.rb
@@ -84,4 +84,22 @@ describe Grim::ImageMagickProcessor do
       (lower_time < higher_time).should be_true
     end
   end
+
+  describe "#save with colorspace option" do
+    before(:each) do
+      @path1 = tmp_path("to_png_spec-1.jpg")
+      @path2 = tmp_path("to_png_spec-2.jpg")
+      @pdf  = Grim::Pdf.new(fixture_path("smoker.pdf"))
+    end
+
+    it "should use colorspace" do
+      Grim::ImageMagickProcessor.new.save(@pdf, 0, @path1, {:colorspace => 'RGB'})
+      Grim::ImageMagickProcessor.new.save(@pdf, 0, @path2, {:colorspace => 'sRGB'})
+
+      file1_size = File.stat(@path1).size
+      file2_size = File.stat(@path2).size
+
+      file1_size.should_not == file2_size
+    end
+  end
 end

--- a/spec/lib/grim_spec.rb
+++ b/spec/lib/grim_spec.rb
@@ -22,6 +22,10 @@ describe Grim do
     Grim::DENSITY.should == 300
   end
 
+  it "should have COLORSPACE constant set to 'RGB'" do
+    Grim::COLORSPACE.should == 'RGB'
+  end
+
   describe "#reap" do
     it "should return an instance of Grim::Pdf" do
       Grim.reap(fixture_path("smoker.pdf")).class.should == Grim::Pdf


### PR DESCRIPTION
Sometimes you might want to extract images with a colorspace other than RGB, this allows you to do that.
