### PR TITLE
Make -colorspace argument optional

### DIFF
--- a/lib/grim/image_magick_processor.rb
+++ b/lib/grim/image_magick_processor.rb
@@ -36,7 +36,7 @@ module Grim
       command << "-antialias"
       command << "-render"
       command << "-quality #{quality}"
-      command << "-colorspace #{colorspace}"
+      command << "-colorspace #{colorspace}" unless colorspace.nil?
       command << "-interlace none"
       command << "-density #{density}"
       command << "#{Shellwords.shellescape(pdf.path)}[#{index}]"

--- a/spec/lib/grim/image_magick_processor_spec.rb
+++ b/spec/lib/grim/image_magick_processor_spec.rb
@@ -128,4 +128,17 @@ describe Grim::ImageMagickProcessor do
       expect(`convert #{@path2} -verbose info:`.downcase.include?("alpha")).to be(false)
     end
   end
+
+  describe "#prepare_command" do
+    before(:each) do
+      @path = tmp_path("to_png_spec.jpg")
+      @pdf  = Grim::Pdf.new(fixture_path("smoker.pdf"))
+    end
+
+    it "removes -colorspace if colorspace option is nil" do
+      processor = Grim::ImageMagickProcessor.new
+      expect(processor.prepare_command(@pdf, 0, @path, {:colorspace => nil}).join(" ")).not_to \
+        match(/-colorspace/)
+    end
+  end
 end


### PR DESCRIPTION
It will still default to 'RGB' but if you explicitly pass in `save..., colorspace: nil` it will leave out the `-colorspace` option and let imagemagick figure out the best colorspace on it's own.

We've seen some problems with the `-colorspace RGB` flag causing the conversion of some PDF files to freeze, but this fixed the issue for us.