### PR TITLE
Save file to path which includes shell meta character

### DIFF
--- a/lib/grim/image_magick_processor.rb
+++ b/lib/grim/image_magick_processor.rb
@@ -59,7 +59,7 @@ module Grim
       command << "-interlace none"
       command << "-density #{density}"
       command << "#{Shellwords.shellescape(pdf.path)}[#{index}]"
-      command << path
+      command << Shellwords.shellescape(path)
 
       command
     end

--- a/spec/lib/grim/image_magick_processor_spec.rb
+++ b/spec/lib/grim/image_magick_processor_spec.rb
@@ -50,6 +50,20 @@ describe Grim::ImageMagickProcessor do
     end
   end
 
+  describe "#save to path includes shell meta character" do
+    before(:all) do
+      @path = tmp_path("to_png_spec(1).png")
+      @pdf  = Grim::Pdf.new(fixture_path("smoker.pdf"))
+
+      @processor = Grim::ImageMagickProcessor.new
+    end
+
+    it "should success" do
+      @processor.save(@pdf, 0, @path, {})
+      expect(File.exist?(@path)).to be(true)
+    end
+  end
+
   describe "#save with width option" do
     before(:each) do
       @path = tmp_path("to_png_spec.png")


### PR DESCRIPTION
Path for saved file wasn't escaped and throwing exception below.

```
Grim::UnprocessablePage:
   sh: -c: line 0: syntax error near unexpected token `('
   sh: -c: line 0: `convert -resize 1024 -antialias -render -quality 90 -colorspace RGB -interlace none -density 300 /Users/fujimura/.ghq/github.com/jonmagic/grim/spec/fixtures/smoker.pdf[0] /Users/fujimura/.ghq/github.com/jonmagic/grim/tmp/to_png_spec(1).png'
```