### PR TITLE
Make -resize optional

### DIFF
--- a/lib/grim/image_magick_processor.rb
+++ b/lib/grim/image_magick_processor.rb
@@ -50,7 +50,7 @@ module Grim
 
       command = []
       command << @imagemagick_path
-      command << "-resize #{width}"
+      command << "-resize #{width}" if width
       command << "-alpha #{alpha}" if alpha
       command << "-antialias"
       command << "-render"


### PR DESCRIPTION
Hi, 
I'd like to generate images without resizing them, thought we should make this option optional, so if we set width option to nil, imagemagick will ignore the resize option. This is a quick and dirty solution, a more elegant one is we should not set the default width in the first place, let the end user set the value through option if they want.
