### PR TITLE
Update Ghostscript to use NOSAFER mode

### DIFF
--- a/lib/grim/image_magick_processor.rb
+++ b/lib/grim/image_magick_processor.rb
@@ -15,7 +15,7 @@ module Grim
     end
 
     def count(path)
-      command = [@ghostscript_path, "-dNODISPLAY", "-q",
+      command = [@ghostscript_path, "-dNODISPLAY", "-dNOSAFER", "-q",
         "-sFile=#{Shellwords.shellescape(path)}",
         File.expand_path('../../../lib/pdf_info.ps', __FILE__)]
       result = `#{command.join(' ')}`


### PR DESCRIPTION
As of Ghostscript 9.5.0, SAFER mode/file access controls are enabled by default. SAFER mode prevents the reading of files, which obviously prevents the reading of the page count.

https://www.ghostscript.com/doc/current/History9.htm#Version9.50
https://www.ghostscript.com/doc/current/Use.htm#NoSafer